### PR TITLE
prop: Remove useless ro.enable_boot_charger_mode

### DIFF
--- a/system_prop.mk
+++ b/system_prop.mk
@@ -66,8 +66,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.timed.enable=true \
     wifi.interface=wlan0 \
     ro.qualcomm.bt.hci_transport=smd \
-    persist.sys.isUsbOtgEnabled=true \
-    ro.enable_boot_charger_mode=1
+    persist.sys.isUsbOtgEnabled=true
 
 # QC Perf
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
This actually belongs in PRODUCT_DEFAULT_PROPERTY_OVERRIDES,
but we don't need it anyway, so remove it.

Change-Id: I1baa3a032be6c9428d1aa2d644de8e92d6271cbd